### PR TITLE
Approximate "Prettier for Ruby" with Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,6 +41,164 @@ Naming/PredicateName:
 
 # ----------------------------------- LAYOUT
 
+Layout/AccessModifierIndentation:
+  Enabled: true
+
+Layout/HashAlignment:
+  Enabled: true
+  EnforcedColonStyle: key
+  EnforcedLastArgumentHashStyle: always_inspect
+
+Layout/ParameterAlignment:
+  Enabled: true
+  EnforcedStyle: with_first_parameter
+
+Layout/BlockAlignment:
+  Enabled: true
+  EnforcedStyleAlignWith: start_of_block
+
+Layout/CaseIndentation:
+  Enabled: true
+
+Layout/ClosingParenthesisIndentation:
+  Enabled: true
+
+Layout/DotPosition:
+  EnforcedStyle: leading
+
+Layout/EmptyLineBetweenDefs:
+  Enabled: true
+
+Layout/EmptyLines:
+  Enabled: true
+
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+
+Layout/EmptyLinesAroundAccessModifier:
+  Enabled: true
+
+Layout/EmptyLinesAroundBlockBody:
+  Enabled: true
+
+# Note(maxh): Not sure about this one given we already have EmptyLines above.
+Layout/EmptyLinesAroundClassBody:
+  Enabled: true
+
+# Why AllowForAlignment: false?
+# 1) Cleaner diffs. For example, when you add a longer key to a hash,
+#    you need to update all the other rows to maintain alignment. This
+#    means your diffs become harder to read. It looks like more is changing
+#    than actually is.
+# 2) Better to have one way to do things than two.
+# 3) You can still use rubocop:disable comments in exceptional cases.
+Layout/ExtraSpacing:
+  Enabled: true
+  AllowForAlignment: false
+
+Layout/FirstArrayElementLineBreak:
+  Enabled: true
+
+Layout/FirstHashElementLineBreak:
+  Enabled: true
+
+Layout/FirstMethodArgumentLineBreak:
+  Enabled: true
+
+Layout/HeredocArgumentClosingParenthesis:
+  Enabled: true
+
+Layout/FirstArgumentIndentation:
+  Enabled: true
+  EnforcedStyle: consistent
+
+Layout/FirstArrayElementIndentation:
+  Enabled: true
+  EnforcedStyle: consistent
+
+Layout/FirstHashElementIndentation:
+  Enabled: true
+  EnforcedStyle: consistent
+
+Layout/FirstParameterIndentation:
+  Enabled: true
+  EnforcedStyle: consistent
+
+Layout/IndentationConsistency:
+  Enabled: true
+
+Layout/IndentationWidth:
+  Enabled: true
+
+Layout/LeadingCommentSpace:
+  Enabled: true
+
+Layout/MultilineArrayLineBreaks:
+  Enabled: true
+
+Layout/MultilineBlockLayout:
+  Enabled: true
+
+Layout/MultilineHashBraceLayout:
+  Enabled: true
+
+Layout/MultilineHashKeyLineBreaks:
+  Enabled: true
+
+Layout/MultilineMethodArgumentLineBreaks:
+  Enabled: true
+
+Layout/MultilineMethodCallBraceLayout:
+  Enabled: true
+
+Layout/MultilineMethodCallIndentation:
+  Enabled: true
+  EnforcedStyle: indented
+
+Layout/MultilineOperationIndentation:
+  Enabled: true
+
+# This doesn't play nice with private_class_method.
+Layout/RescueEnsureAlignment:
+  Enabled: false
+
+Layout/SpaceAfterComma:
+  Enabled: true
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: true
+
+Layout/SpaceAroundOperators:
+  Enabled: true
+
+Layout/SpaceBeforeBlockBraces:
+  Enabled: true
+
+Layout/SpaceBeforeFirstArg:
+  Enabled: false
+
+Layout/SpaceInsideBlockBraces:
+  Enabled: true
+  EnforcedStyle: space
+
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: true
+  EnforcedStyle: no_space
+
+Layout/SpaceInLambdaLiteral:
+  Enabled: true
+  SupportedStyles:
+    - require_no_space
+
+# Enforce final new line.
+Layout/TrailingEmptyLines:
+  Enabled: true
+  SupportedStyles:
+    - final_newline
+
+Layout/TrailingWhitespace:
+  Enabled: true
+
 Layout/LineLength:
   Enabled: true
   Max: 120
@@ -56,3 +214,39 @@ Layout/LineLength:
 Performance:
   Exclude:
     - '**/test/**/*'
+
+# ----------------------------------- LINTING
+
+Lint/AmbiguousBlockAssociation:
+  Enabled: true
+  inherit_mode:
+  # RSpec has a canonical syntax that violates this rule
+  Exclude:
+    - !ruby/regexp /_spec\.rb$/
+
+Lint/AssignmentInCondition:
+  Enabled: false
+
+Lint/BigDecimalNew:
+  Enabled: false
+
+Lint/HeredocMethodCallPosition:
+  Enabled: true
+
+Lint/NestedMethodDefinition:
+  Enabled: true
+  # Sandbox uses Sinatra which is heavily uses nested methods
+  Exclude:
+    - !ruby/regexp /sandbox/dashboard/app/.*.rb/
+
+Lint/ShadowingOuterLocalVariable:
+  Enabled: false
+
+Lint/UnusedMethodArgument:
+  Enabled: false
+
+# ----------------------------------- METRICS
+
+Metrics/LineLength:
+  Max: 120
+  AutoCorrect: true


### PR DESCRIPTION
This may be an unpopular opinion. I'd like to make a case for using an
opinionated formatter for Ruby code. This is intended to be used with your
preferred editor's integration with **Rubocop** to automatically format your
code on save, as well as part of a CI workflow.

The idea and code are not my own, but rather have been shamelessly stolen from [this great
article](https://flexport.engineering/approximating-prettier-for-ruby-with-rubocop-8b863bd64dc6). This PR is less about the individual cops—which can be customized to fit our
needs—and more about starting a conversation about whether we should employ such
tools.

----

# Consistency is more important than individual styles

Whether we use single- or double-quotes is less important than having that (and
all other styles) be consistent with:

- the project's codebase
- our other projects
- our external contractors' practices
- external libraries
- the Ruby community

I'm not the only one who thinks so. The below image, taken from [Hierarchy of
Software Needs](https://naildrivin5.com/blog/2016/01/13/hierarchy-of-software-needs.html#need-for-consistency), begins to explain how important *consistency* and *collective experience* 
are to development.

![Programmers' hierarchy of
needs](https://naildrivin5.com/images/programming_hierarchy_of_needs.png)

This, of course, is not achievable using computers alone; it takes ongoing
vigilance by each developer. But computers can get us a good part of the way
there in an automated fashion, allowing us developers to concentrate on the
edge-cases that require mushy grey-matter.

# Prettier, but betterer

I'm sure many of you have used **Prettier** for your JavaScript code. Indeed,
there's a Ruby plugin for Prettier. The first article I linked to explains why
they choose not to use it. In brief, it is not stable enough for production, and
Rubocop does much more than just code formatting. The cops in this PR produce
similar results, and you get all the other benefits of using Rubocop.

# Why I like it

I like this setup for the same reasons that Prettier is so popular. As Animikii
grows, this will only become more important. Especially as we begin to do more
structured PR's, it will ensure that the submitted code meets a baseline of
formatting, and reviewers can concentrate on more weighty things.

# Let's talk

This PR is meant to spark a conversation. There are probably great reasons _not_
to auto-format code, and I am not the most experienced dev on the team. Having
this shot down is no problem, especially if I can learn from it.